### PR TITLE
Fix RotationHeuristic not resetting data

### DIFF
--- a/src/main/java/me/nik/anticheatbase/utils/custom/aim/RotationHeuristics.java
+++ b/src/main/java/me/nik/anticheatbase/utils/custom/aim/RotationHeuristics.java
@@ -62,8 +62,11 @@ public class RotationHeuristics {
         /*
         Collection is finished, No more data can be processed.
          */
-        if (isFinished()) return;
-
+        if (isFinished()) {
+            reset() // Clear data
+            return;
+        }
+        
         /*
         If this is the last element we're going to process, Get the correct average amount.
         Otherwise add the amount in order to use the average variable as our sum.


### PR DESCRIPTION
Before this caused the Heuristic to be the same all the time, never reset