### PR TITLE
Fix ClientBrandListener delay

### DIFF
--- a/src/main/java/me/nik/anticheatbase/listeners/ClientBrandListener.java
+++ b/src/main/java/me/nik/anticheatbase/listeners/ClientBrandListener.java
@@ -89,6 +89,6 @@ public class ClientBrandListener extends PacketAdapter {
 
             profile.setClient(brand);
 
-        }, 2000L);
+        }, 40L);
     }
 }


### PR DESCRIPTION
The delay is supposed to be given in ticks instead of milliseconds